### PR TITLE
Override modal default to fullscreen for iOS 13 and above

### DIFF
--- a/src/ios/webview/WebViewPlugin.m
+++ b/src/ios/webview/WebViewPlugin.m
@@ -49,6 +49,13 @@ NSArray* results;
           webViewController = [[WebViewController alloc] init];
           webViewController.delegate = self; // esto es para poder recibir el evento de que webView se cerro
           webViewController.startPage = url;
+
+          // iOS 13 onwards opens this modal in a "card stack" overlay, which cuts off the
+          // bottom of the modal (therefore the webview), so we set fullscreen mode
+          if (@available(iOS 13.0, *)) {
+              webViewController.modalPresentationStyle = UIModalPresentationFullScreen;
+          }
+
           [self.viewController presentViewController:webViewController animated:YES completion:nil];
       });
 


### PR DESCRIPTION
**Before (iOS 13.0 iPhone 8)**
![image (4)](https://user-images.githubusercontent.com/13977568/88352196-5271bf80-cd9c-11ea-84a4-904f1c4d95c5.png)

**After**
![image](https://user-images.githubusercontent.com/13977568/88352123-07f04300-cd9c-11ea-8614-59cd765246a5.png)
